### PR TITLE
Update requirements.txt ( added OPENXMLLIB )

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ future
 pyOpenSSL>=16.2.0
 python-docx>=0.8.10
 python-pptx>=0.6.18
+openxmllib>=1.1.1


### PR DESCRIPTION
openxmllib is a toolkit that handles the new ECMA 376 office file
formats known as OpenXML, added to requirements.txt as it was pending being requested at the time of use on systems that do not patch through the latest python version and missing packages.